### PR TITLE
chore: add repo hygiene templates, docs, and Lua smoke check

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,155 @@
+name: Bug Report
+description: Report a reproducible bug, setup issue, or runtime problem in TajsGraphBM
+title: "[Bug] "
+labels: ["bug"]
+assignees:
+  - tajemniktv
+body:
+  - type: markdown
+    attributes:
+      value: "## Thanks for helping improve TajsGraphBM\nPlease **search existing issues** before opening a new one. Include versions, console commands used, and logs."
+  - type: input
+    id: tajsgraphbm_version
+    attributes:
+      label: TajsGraphBM version/commit
+      placeholder: "e.g. main branch, commit abc123"
+      validations:
+        required: true
+  - type: input
+    id: bettermart_version
+    attributes:
+      label: BetterMart build/version
+      placeholder: "e.g. 1.2.3"
+      validations:
+        required: true
+  - type: input
+    id: ue4ss_version
+    attributes:
+      label: UE4SS version/tag
+      placeholder: "e.g. experimental-latest"
+      validations:
+        required: true
+  - type: input
+    id: signature_source
+    attributes:
+      label: Signature/config set source
+      placeholder: "e.g. RE-UE4SS feat/bettermartconfig"
+      validations:
+        required: true
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Installation method
+      options:
+        - Manual multi-repo setup
+        - Bundled release
+        - Local dev checkout
+        - Not sure
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Install/setup
+        - Command behavior
+        - Light patching / runtime tuning
+        - Render/Lumen/MegaLights
+        - Engine.ini / CVars
+        - Performance
+        - Crash / instability
+        - Docs / tooling
+        - Other
+      validations:
+        required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      placeholder: "What happened? What was expected?"
+      validations:
+        required: true
+  - type: textarea
+    id: reproduction_steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: "Step-by-step instructions to trigger the bug"
+      validations:
+        required: true
+  - type: textarea
+    id: console_commands
+    attributes:
+      label: Console commands used
+      placeholder: "e.g. tajsgraph.apply, tajsgraph.status"
+      validations:
+        required: true
+  - type: textarea
+    id: scene_save_context
+    attributes:
+      label: Scene / save context
+      placeholder: "Map, building, or save state where bug occurred"
+      validations:
+        required: false
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected behavior
+      validations:
+        required: false
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual behavior
+      validations:
+        required: true
+  - type: dropdown
+    id: frequency
+    attributes:
+      label: Frequency
+      options:
+        - Every time
+        - Often (>50%)
+        - Sometimes
+        - Rarely
+        - Once
+      validations:
+        required: true
+  - type: checkboxes
+    id: diagnostics
+    attributes:
+      label: Diagnostics checks
+      options:
+        - Ran `tajsgraph.status`
+        - VSM pulse/reload considered
+        - Tested with fresh game launch
+        - Tested without unrelated ini/mod changes
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: "OS, GPU, CPU, driver versions, DX12/Vulkan, etc."
+      validations:
+        required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / console output
+      placeholder: "Paste relevant logs or stack traces"
+      validations:
+        required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / additional context
+      placeholder: "Optional screenshots, video, or extra notes"
+      validations:
+        required: false
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Please confirm
+      options:
+        - Searched existing issues
+        - Provided versions and setup info
+        - Included reproduction steps and expected/actual behavior

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,102 +7,91 @@ assignees:
 body:
   - type: markdown
     attributes:
-      value: "## Thanks for helping improve TajsGraphBM\nPlease **search existing issues** before opening a new one. Include versions, console commands used, and logs."
+      value: |
+        ## Thanks for helping improve TajsGraphBM
+        Please **search existing issues** before opening a new one.
+        Include versions, reproduction steps, and logs/screenshots when possible.
+
   - type: input
     id: tajsgraphbm_version
     attributes:
-      label: TajsGraphBM version/commit
+      label: TajsGraphBM version / commit
       placeholder: "e.g. main branch, commit abc123"
-      validations:
-        required: true
+    validations:
+      required: true
+
   - type: input
     id: bettermart_version
     attributes:
-      label: BetterMart build/version
+      label: BetterMart build / version
       placeholder: "e.g. 1.2.3"
-      validations:
-        required: true
+    validations:
+      required: true
+
   - type: input
     id: ue4ss_version
     attributes:
-      label: UE4SS version/tag
+      label: UE4SS version / tag
       placeholder: "e.g. experimental-latest"
-      validations:
-        required: true
-  - type: input
-    id: signature_source
-    attributes:
-      label: Signature/config set source
-      placeholder: "e.g. RE-UE4SS feat/bettermartconfig"
-      validations:
-        required: true
-  - type: dropdown
-    id: install_method
-    attributes:
-      label: Installation method
-      options:
-        - Manual multi-repo setup
-        - Bundled release
-        - Local dev checkout
-        - Not sure
     validations:
       required: true
+
   - type: dropdown
     id: category
     attributes:
       label: Category
       options:
-        - Install/setup
-        - Command behavior
-        - Light patching / runtime tuning
-        - Render/Lumen/MegaLights
-        - Engine.ini / CVars
+        - General
+        - Runtime / visuals
+        - Configuration
         - Performance
+        - Setup
         - Crash / instability
         - Docs / tooling
-        - Other
-      validations:
-        required: true
+        - Other / not sure
+    validations:
+      required: true
+
   - type: textarea
     id: description
     attributes:
       label: Describe the bug
       placeholder: "What happened? What was expected?"
-      validations:
-        required: true
+    validations:
+      required: true
+
   - type: textarea
     id: reproduction_steps
     attributes:
       label: Steps to reproduce
       placeholder: "Step-by-step instructions to trigger the bug"
-      validations:
-        required: true
-  - type: textarea
-    id: console_commands
-    attributes:
-      label: Console commands used
-      placeholder: "e.g. tajsgraph.apply, tajsgraph.status"
-      validations:
-        required: true
+    validations:
+      required: true
+
   - type: textarea
     id: scene_save_context
     attributes:
       label: Scene / save context
       placeholder: "Map, building, or save state where bug occurred"
-      validations:
-        required: false
+    validations:
+      required: false
+
   - type: textarea
     id: expected_behavior
     attributes:
       label: Expected behavior
-      validations:
-        required: false
+      placeholder: "What should have happened?"
+    validations:
+      required: false
+
   - type: textarea
     id: actual_behavior
     attributes:
       label: Actual behavior
-      validations:
-        required: true
+      placeholder: "What happened instead?"
+    validations:
+      required: true
+
   - type: dropdown
     id: frequency
     attributes:
@@ -113,43 +102,38 @@ body:
         - Sometimes
         - Rarely
         - Once
-      validations:
-        required: true
-  - type: checkboxes
-    id: diagnostics
-    attributes:
-      label: Diagnostics checks
-      options:
-        - Ran `tajsgraph.status`
-        - VSM pulse/reload considered
-        - Tested with fresh game launch
-        - Tested without unrelated ini/mod changes
+    validations:
+      required: true
+
   - type: textarea
     id: environment
     attributes:
       label: Environment
       placeholder: "OS, GPU, CPU, driver versions, DX12/Vulkan, etc."
-      validations:
-        required: true
+    validations:
+      required: true
+
   - type: textarea
     id: logs
     attributes:
       label: Logs / console output
       placeholder: "Paste relevant logs or stack traces"
-      validations:
-        required: false
+    validations:
+      required: false
+
   - type: textarea
     id: screenshots
     attributes:
       label: Screenshots / additional context
       placeholder: "Optional screenshots, video, or extra notes"
-      validations:
-        required: false
+    validations:
+      required: false
+
   - type: checkboxes
     id: confirmations
     attributes:
       label: Please confirm
       options:
-        - Searched existing issues
-        - Provided versions and setup info
-        - Included reproduction steps and expected/actual behavior
+        - label: I searched existing issues.
+        - label: I provided versions and setup context.
+        - label: I included reproduction steps and expected/actual behavior.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "Project README"
+    url: "https://github.com/tajemniktv/TajsGraphBM/blob/main/README.md"
+    about: "Check installation, setup requirements, and available console commands first."
+  - name: "Manual Test & Regression Checklist"
+    url: "https://github.com/tajemniktv/TajsGraphBM/blob/main/docs/MANUAL_TEST_CHECKLIST.md"
+    about: "Review the recommended sanity checks before reporting regressions or validating changes."
+  - name: "Known Good Versions / Compatibility"
+    url: "https://github.com/tajemniktv/TajsGraphBM/blob/main/docs/KNOWN_GOOD_VERSIONS.md"
+    about: "See the currently recommended BetterMart, UE4SS, and signature/config combinations."

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,44 +7,50 @@ assignees:
 body:
   - type: markdown
     attributes:
-      value: "## Thanks for the suggestion\nPlease **search existing issues** before submitting. Explain the problem, propose a solution, and include acceptance criteria."
+      value: |
+        ## Thanks for the suggestion
+        Please **search existing issues** before submitting.
+        The best requests explain the problem, propose a solution, and include acceptance criteria.
+
   - type: textarea
     id: summary
     attributes:
       label: Summary of requested feature
       placeholder: "One or two sentences describing the request"
-      validations:
-        required: true
+    validations:
+      required: true
+
   - type: textarea
     id: motivation
     attributes:
       label: Problem / motivation
-      placeholder: "Explain why this is needed, what friction it solves"
-      validations:
-        required: true
+      placeholder: "Explain why this is needed and what friction it solves"
+    validations:
+      required: true
+
   - type: textarea
     id: proposed_solution
     attributes:
       label: Proposed solution
-      placeholder: "Describe desired behavior, UX, default values, settings, or toggles"
-      validations:
-        required: true
+      placeholder: "Describe desired behavior, UX, defaults, settings, or toggles"
+    validations:
+      required: true
+
   - type: dropdown
     id: category
     attributes:
       label: Category
       options:
-        - Runtime patching / lighting
-        - Renderer / Lumen / Megalights
-        - Config / Engine.ini / profiles
-        - Installation / distribution
-        - Diagnostics / status
-        - Docs / tooling
+        - General
+        - Runtime / visuals
+        - Configuration
         - Performance / compatibility
-        - Quality-of-life
-        - Other
-      validations:
-        required: true
+        - Setup / distribution
+        - Diagnostics / tooling
+        - Other / not sure
+    validations:
+      required: true
+
   - type: dropdown
     id: scope
     attributes:
@@ -54,27 +60,33 @@ body:
         - Medium (new setting / moderate logic)
         - Large (multi-part feature; needs planning)
         - Not sure
-      validations:
-        required: true
+    validations:
+      required: true
+
   - type: checkboxes
     id: touched_areas
     attributes:
-      label: Runtime targets affected
+      label: Affected areas
       options:
-        - Scripts / runtime modules
-        - Engine.ini / CVars
-        - Mod packaging / distribution
-        - Docs or issue templates
-        - Not sure
+        - label: Scripts / runtime modules
+        - label: Engine.ini / config / profiles
+        - label: Packaging / distribution
+        - label: Diagnostics / status / commands
+        - label: Docs / templates / tooling
+        - label: Not sure
+
   - type: textarea
     id: acceptance_criteria
     attributes:
       label: Acceptance criteria
       placeholder: "Conditions to consider the feature complete"
-      validations:
-        required: true
+    validations:
+      required: true
+
   - type: textarea
     id: additional_context
     attributes:
       label: Additional context (optional)
-      placeholder: "Extra details or references"
+      placeholder: "Extra details, mockups, references, or notes"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,80 @@
+name: Feature Request
+description: Suggest an idea or improvement for TajsGraphBM
+title: "[Feature] "
+labels: ["enhancement"]
+assignees:
+  - tajemniktv
+body:
+  - type: markdown
+    attributes:
+      value: "## Thanks for the suggestion\nPlease **search existing issues** before submitting. Explain the problem, propose a solution, and include acceptance criteria."
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary of requested feature
+      placeholder: "One or two sentences describing the request"
+      validations:
+        required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Problem / motivation
+      placeholder: "Explain why this is needed, what friction it solves"
+      validations:
+        required: true
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed solution
+      placeholder: "Describe desired behavior, UX, default values, settings, or toggles"
+      validations:
+        required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Runtime patching / lighting
+        - Renderer / Lumen / Megalights
+        - Config / Engine.ini / profiles
+        - Installation / distribution
+        - Diagnostics / status
+        - Docs / tooling
+        - Performance / compatibility
+        - Quality-of-life
+        - Other
+      validations:
+        required: true
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Small (tweak / small option)
+        - Medium (new setting / moderate logic)
+        - Large (multi-part feature; needs planning)
+        - Not sure
+      validations:
+        required: true
+  - type: checkboxes
+    id: touched_areas
+    attributes:
+      label: Runtime targets affected
+      options:
+        - Scripts / runtime modules
+        - Engine.ini / CVars
+        - Mod packaging / distribution
+        - Docs or issue templates
+        - Not sure
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      placeholder: "Conditions to consider the feature complete"
+      validations:
+        required: true
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional context (optional)
+      placeholder: "Extra details or references"

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,56 @@
+name: Question / Support
+description: Ask a question or request help with TajsGraphBM
+title: "[Question]: "
+labels: ["question"]
+assignees:
+  - tajemniktv
+body:
+  - type: markdown
+    attributes:
+      value: "## Thanks for reaching out\nPlease search existing issues and documentation before submitting. Use this form for questions, usage help, or clarification requests."
+  - type: textarea
+    id: summary
+    attributes:
+      label: Brief summary of your question
+      placeholder: "Example: How to model recurring light patches across maps?"
+      validations:
+        required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      placeholder: "Context, what you tried, expected behavior"
+      validations:
+        required: true
+  - type: dropdown
+    id: platform_target
+    attributes:
+      label: Platform target
+      options:
+        - BetterMart game
+        - UE4SS runtime
+        - Scripts / Mods
+        - Not sure
+      validations:
+        required: false
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you tried?
+      placeholder: "Steps taken to resolve or explore issue"
+      validations:
+        required: false
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      placeholder: "Any extra info that might help"
+      validations:
+        required: false
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: Please confirm
+      options:
+        - Searched existing issues
+        - This is a general question / support request, not bug or feature

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -7,21 +7,27 @@ assignees:
 body:
   - type: markdown
     attributes:
-      value: "## Thanks for reaching out\nPlease search existing issues and documentation before submitting. Use this form for questions, usage help, or clarification requests."
+      value: |
+        ## Thanks for reaching out
+        Please search existing issues and documentation before submitting.
+        Use this form for questions, usage help, or clarification requests.
+
   - type: textarea
     id: summary
     attributes:
       label: Brief summary of your question
-      placeholder: "Example: How to model recurring light patches across maps?"
-      validations:
-        required: true
+      placeholder: "Example: Why does a scene only update after a second apply?"
+    validations:
+      required: true
+
   - type: textarea
     id: details
     attributes:
       label: Details
       placeholder: "Context, what you tried, expected behavior"
-      validations:
-        required: true
+    validations:
+      required: true
+
   - type: dropdown
     id: platform_target
     attributes:
@@ -31,26 +37,29 @@ body:
         - UE4SS runtime
         - Scripts / Mods
         - Not sure
-      validations:
-        required: false
+    validations:
+      required: false
+
   - type: textarea
     id: tried
     attributes:
       label: What have you tried?
-      placeholder: "Steps taken to resolve or explore issue"
-      validations:
-        required: false
+      placeholder: "Steps taken to resolve or explore the question"
+    validations:
+      required: false
+
   - type: textarea
     id: additional
     attributes:
       label: Additional context
       placeholder: "Any extra info that might help"
-      validations:
-        required: false
+    validations:
+      required: false
+
   - type: checkboxes
     id: confirmations
     attributes:
       label: Please confirm
       options:
-        - Searched existing issues
-        - This is a general question / support request, not bug or feature
+        - label: I searched existing issues.
+        - label: This is a general question or support request, not a bug or feature request.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,43 @@
+- name: "bug"
+  color: "d73a4a"
+  description: "Something is broken or behaving incorrectly"
+
+- name: "enhancement"
+  color: "a2eeef"
+  description: "New feature or improvement"
+
+- name: "question"
+  color: "d876e3"
+  description: "General question or support request"
+
+- name: "category/general"
+  color: "ededed"
+  description: "General or mixed-scope work"
+
+- name: "category/runtime-visuals"
+  color: "1d76db"
+  description: "Runtime lighting, rendering, or visual behavior"
+
+- name: "category/configuration"
+  color: "fbca04"
+  description: "Config, profiles, Engine.ini, or settings-related work"
+
+- name: "category/performance"
+  color: "5319e7"
+  description: "Performance, efficiency, or runtime overhead"
+
+- name: "category/setup-distribution"
+  color: "0e8a16"
+  description: "Installation, packaging, or distribution workflow"
+
+- name: "category/tooling-docs"
+  color: "0052cc"
+  description: "Tooling, templates, workflows, or documentation"
+
+- name: "category/stability"
+  color: "b60205"
+  description: "Crash, instability, or reliability-related work"
+
+- name: "category/other"
+  color: "c2e0c6"
+  description: "Other or not yet categorized"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+# Pull Request
+
 ## Summary
 
 What does this PR change? Keep it short and concrete.
@@ -27,8 +29,6 @@ How was this tested?
 
 - BetterMart version/build:
 - UE4SS version/tag:
-- Signature/config source:
-- Commands used:
 - Scene/save tested:
 - Result:
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,18 @@ Link issues here (for example: `Fixes #16`, `Related to #5`).
 - [ ] Docs / tooling / repo hygiene
 - [ ] Other:
 
+## Category
+
+_Select the single best-fit category for this PR._
+
+- [ ] General
+- [ ] Runtime / visuals
+- [ ] Configuration
+- [ ] Performance
+- [ ] Setup / distribution
+- [ ] Tooling / docs
+- [ ] Other / not sure
+
 ## Testing
 
 How was this tested?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,57 @@
+## Summary
+
+What does this PR change? Keep it short and concrete.
+
+## Related Issue(s)
+
+Link issues here (for example: `Fixes #16`, `Related to #5`).
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor / cleanup (no intended behavior change)
+- [ ] Docs / tooling / repo hygiene
+- [ ] Other:
+
+## Testing
+
+How was this tested?
+
+- [ ] Tested in BetterMart
+- [ ] Tested command flow / console behavior
+- [ ] Only partially tested (explain below)
+- [ ] Unable to test (explain below)
+
+### Test notes
+
+- BetterMart version/build:
+- UE4SS version/tag:
+- Signature/config source:
+- Commands used:
+- Scene/save tested:
+- Result:
+
+## Screenshots / video (if visual)
+
+Add before/after screenshots or a short clip if the PR changes visuals.
+
+## Behavior / compatibility notes
+
+- [ ] This PR changes expected runtime behavior, config defaults, or workflow in a meaningful way
+- [ ] This PR may affect performance, startup behavior, or scene transition behavior
+- [ ] This PR may affect compatibility with a specific BetterMart / UE4SS combination
+
+If any box above is checked, explain briefly:
+
+## Checklist
+
+- [ ] My changes are focused and do not include unrelated churn
+- [ ] I followed the existing module/style patterns
+- [ ] I updated docs/comments/templates where needed
+- [ ] I considered regression risk for commands, patching flow, and logs
+- [ ] I did not redistribute bundled third-party binaries in this PR
+
+## Extra notes
+
+Anything else maintainers should know: edge cases, follow-ups, limitations, or untested paths.

--- a/.github/workflows/auto-category-labels.yml
+++ b/.github/workflows/auto-category-labels.yml
@@ -1,0 +1,177 @@
+name: Auto Category Labels
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - ready_for_review
+
+jobs:
+  label-issue-category:
+    if: github.event_name == 'issues'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - name: Apply category label from issue body
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+
+            const categoryLabels = [
+              'category/general',
+              'category/runtime-visuals',
+              'category/configuration',
+              'category/performance',
+              'category/setup-distribution',
+              'category/tooling-docs',
+              'category/stability',
+              'category/other',
+            ];
+
+            const sectionMatch = body.match(/###\s+Category\s*\n\n([\s\S]*?)(?:\n###\s+|$)/i);
+            if (!sectionMatch) {
+              core.info('No Category section found in issue body; skipping.');
+              return;
+            }
+
+            const rawCategory = sectionMatch[1].trim().split('\n')[0].trim();
+            core.info(`Detected issue category: ${rawCategory}`);
+
+            const mapping = {
+              'General': 'category/general',
+              'Runtime / visuals': 'category/runtime-visuals',
+              'Configuration': 'category/configuration',
+              'Performance': 'category/performance',
+              'Performance / compatibility': 'category/performance',
+              'Setup': 'category/setup-distribution',
+              'Setup / distribution': 'category/setup-distribution',
+              'Docs / tooling': 'category/tooling-docs',
+              'Diagnostics / tooling': 'category/tooling-docs',
+              'Crash / instability': 'category/stability',
+              'Other / not sure': 'category/other',
+            };
+
+            const targetLabel = mapping[rawCategory];
+            if (!targetLabel) {
+              core.info('No category label mapping found; skipping.');
+              return;
+            }
+
+            const existing = (issue.labels || []).map(label => typeof label === 'string' ? label : label.name).filter(Boolean);
+            const labelsToRemove = existing.filter(label => categoryLabels.includes(label) && label !== targetLabel);
+
+            for (const label of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  name: label,
+                });
+              } catch (error) {
+                core.info(`Could not remove label ${label}: ${error.message}`);
+              }
+            }
+
+            if (!existing.includes(targetLabel)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: [targetLabel],
+              });
+            }
+
+  label-pr-category:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+      contents: read
+    steps:
+      - name: Apply category label from PR body
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+
+            const categoryLabels = [
+              'category/general',
+              'category/runtime-visuals',
+              'category/configuration',
+              'category/performance',
+              'category/setup-distribution',
+              'category/tooling-docs',
+              'category/stability',
+              'category/other',
+            ];
+
+            const sectionMatch = body.match(/##\s+Category\s*\n\n([\s\S]*?)(?:\n##\s+|$)/i);
+            if (!sectionMatch) {
+              core.info('No Category section found in PR body; skipping.');
+              return;
+            }
+
+            const section = sectionMatch[1];
+            const checkedMatch = section.match(/- \[(?:x|X)\]\s+(.+)/);
+            if (!checkedMatch) {
+              core.info('No checked PR category found; skipping.');
+              return;
+            }
+
+            const rawCategory = checkedMatch[1].trim();
+            core.info(`Detected PR category: ${rawCategory}`);
+
+            const mapping = {
+              'General': 'category/general',
+              'Runtime / visuals': 'category/runtime-visuals',
+              'Configuration': 'category/configuration',
+              'Performance': 'category/performance',
+              'Setup / distribution': 'category/setup-distribution',
+              'Tooling / docs': 'category/tooling-docs',
+              'Other / not sure': 'category/other',
+            };
+
+            const targetLabel = mapping[rawCategory];
+            if (!targetLabel) {
+              core.info('No category label mapping found; skipping.');
+              return;
+            }
+
+            const existing = (pr.labels || []).map(label => typeof label === 'string' ? label : label.name).filter(Boolean);
+            const labelsToRemove = existing.filter(label => categoryLabels.includes(label) && label !== targetLabel);
+
+            for (const label of labelsToRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                  name: label,
+                });
+              } catch (error) {
+                core.info(`Could not remove label ${label}: ${error.message}`);
+              }
+            }
+
+            if (!existing.includes(targetLabel)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: [targetLabel],
+              });
+            }

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -21,7 +21,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Sync labels from YAML
         uses: crazy-max/ghaction-github-labeler@v5

--- a/.github/workflows/labels-sync.yml
+++ b/.github/workflows/labels-sync.yml
@@ -1,0 +1,32 @@
+name: Sync Labels
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/labels.yml'
+      - '.github/workflows/labels-sync.yml'
+  pull_request:
+    paths:
+      - '.github/labels.yml'
+      - '.github/workflows/labels-sync.yml'
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Sync labels from YAML
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          skip-delete: true
+          dry-run: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/lua-smoke-check.yml
+++ b/.github/workflows/lua-smoke-check.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Lua
         uses: leafo/gh-actions-lua@v11
@@ -74,9 +74,9 @@ jobs:
           end
 
           local config = require('config')
-          local normalized = config.normalize({ spotlight_force_visible_enabled = true })
-          if normalized.spotlight_runtime_force_visible_enabled ~= true then
-            io.stderr:write('Config alias normalization failed for spotlight_force_visible_enabled\n')
+          local normalized = config.normalize({ spotlight_force_visible_enabled = false })
+          if normalized.spotlight_runtime_force_visible_enabled ~= false then
+            io.stderr:write('Config alias normalization failed: spotlight_force_visible_enabled did not override spotlight_runtime_force_visible_enabled to false\n')
             os.exit(1)
           end
 

--- a/.github/workflows/lua-smoke-check.yml
+++ b/.github/workflows/lua-smoke-check.yml
@@ -1,0 +1,84 @@
+name: Lua Smoke Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lua-smoke-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Lua
+        uses: leafo/gh-actions-lua@v11
+        with:
+          luaVersion: '5.4'
+
+      - name: Compile Lua files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(find Scripts -type f -name '*.lua' | sort)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo 'No Lua files found under Scripts/'
+            exit 1
+          fi
+          for file in "${files[@]}"; do
+            echo "Checking $file"
+            luac -p "$file"
+          done
+
+      - name: Require-shape smoke checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          lua <<'EOF'
+          package.path = table.concat({
+            'Scripts/?.lua',
+            'Scripts/?/init.lua',
+            package.path,
+          }, ';')
+
+          local modules = {
+            { name = 'config', marker = 'config' },
+            { name = 'rt_log', marker = 'rt_log' },
+            { name = 'rt_state', marker = 'rt_state' },
+            { name = 'rt_stats', marker = 'rt_stats' },
+            { name = 'rt_object', marker = 'rt_object' },
+            { name = 'rt_scheduler', marker = 'rt_scheduler' },
+            { name = 'rt_render', marker = 'rt_render' },
+            { name = 'rt_spotlight', marker = 'rt_spotlight' },
+            { name = 'rt_coordinator', marker = 'rt_coordinator' },
+            { name = 'runtime', marker = 'runtime' },
+          }
+
+          for _, entry in ipairs(modules) do
+            local ok, mod = pcall(require, entry.name)
+            if not ok then
+              io.stderr:write(string.format('Failed to require %s: %s\n', entry.name, tostring(mod)))
+              os.exit(1)
+            end
+            if type(mod) ~= 'table' then
+              io.stderr:write(string.format('Module %s did not return a table\n', entry.name))
+              os.exit(1)
+            end
+            if mod.__tajsgraph_module ~= entry.marker then
+              io.stderr:write(string.format('Module %s marker mismatch: expected %s got %s\n', entry.name, entry.marker, tostring(mod.__tajsgraph_module)))
+              os.exit(1)
+            end
+          end
+
+          local config = require('config')
+          local normalized = config.normalize({ spotlight_force_visible_enabled = true })
+          if normalized.spotlight_runtime_force_visible_enabled ~= true then
+            io.stderr:write('Config alias normalization failed for spotlight_force_visible_enabled\n')
+            os.exit(1)
+          end
+
+          print('Lua smoke checks passed')
+          EOF

--- a/Scripts/config.lua
+++ b/Scripts/config.lua
@@ -141,12 +141,6 @@ function M.normalize(config)
         config = {}
     end
 
-    for key, value in pairs(M.defaults) do
-        if config[key] == nil then
-            config[key] = value
-        end
-    end
-
     -- Backward-compatible aliases for previous config keys.
     if config.spotlight_runtime_compat_enabled == nil and config.spotlight_force_runtime_compat ~= nil then
         config.spotlight_runtime_compat_enabled = config.spotlight_force_runtime_compat
@@ -162,6 +156,12 @@ function M.normalize(config)
     end
     if config.spotlight_runtime_force_visible_enabled == nil and config.spotlight_force_visible_enabled ~= nil then
         config.spotlight_runtime_force_visible_enabled = config.spotlight_force_visible_enabled
+    end
+
+    for key, value in pairs(M.defaults) do
+        if config[key] == nil then
+            config[key] = value
+        end
     end
 
     if config.spotlight_tune_mode ~= "absolute" and config.spotlight_tune_mode ~= "multiplier" then

--- a/docs/KNOWN_GOOD_VERSIONS.md
+++ b/docs/KNOWN_GOOD_VERSIONS.md
@@ -1,0 +1,87 @@
+# Known Good Versions / Compatibility
+
+This file is a lightweight compatibility reference for **TajsGraphBM**.
+It is meant to reduce support churn by documenting combinations that are known to work, partially work, or are still unverified.
+
+## How to use this file
+
+When reporting bugs or validating a change, include:
+
+- BetterMart version/build
+- TajsGraphBM commit or release
+- UE4SS version/tag
+- Signature/config source
+- Whether you used the repo `Engine.ini` as-is or with local edits
+- Which console commands were used (`tajsgraph.apply`, `tajsgraph.status`, etc.)
+
+If a setup is not listed here, that does **not** automatically mean it is broken. It just means it has not been documented yet.
+
+---
+
+## Status meanings
+
+- **Known good** — expected to work for normal testing
+- **Partially verified** — works for some paths, but not fully trusted yet
+- **Unverified** — not tested enough to rely on
+- **Known problematic** — has known breakage, instability, or missing functionality
+
+---
+
+## Compatibility matrix
+
+### BetterMart
+
+| Component | Version / source | Status | Notes |
+|---|---|---:|---|
+| BetterMart | Current public build used during active development | Partially verified | Replace with exact build numbers as they are confirmed. |
+
+### TajsGraphBM
+
+| Component | Version / source | Status | Notes |
+|---|---|---:|---|
+| TajsGraphBM | `main` branch (early WIP) | Partially verified | Runtime patching and command flow are still evolving. |
+
+### UE4SS
+
+| Component | Version / source | Status | Notes |
+|---|---|---:|---|
+| UE4SS | `experimental-latest` | Partially verified | This is the currently documented requirement in the README. |
+
+### BetterMart signatures / config
+
+| Component | Version / source | Status | Notes |
+|---|---|---:|---|
+| BetterMart custom game config | `tajemniktv/RE-UE4SS` `feat/bettermartconfig` | Partially verified | This is the currently documented setup source in the README. |
+
+---
+
+## Recommended bug report fields
+
+When opening a bug report, include at minimum:
+
+- BetterMart version/build
+- TajsGraphBM commit or release
+- UE4SS version/tag
+- Signature/config source
+- GPU + driver version
+- Whether `tajsgraph.apply` changed the scene visually
+- Whether the issue still happens after a fresh launch
+- Whether the issue seems related to:
+  - spotlight tuning
+  - runtime compatibility writes
+  - renderer/Lumen/MegaLights writes
+  - post-apply VSM refresh behavior
+
+---
+
+## Notes for maintainers
+
+Update this file whenever one of the following changes:
+
+- BetterMart receives a patch that affects runtime hooks or rendering behavior
+- UE4SS requirement changes
+- Signature/config source changes
+- A release bundle becomes the preferred installation path
+- A previously unstable combination becomes reliable enough to recommend
+
+If exact versions are not known yet, prefer writing **honest placeholders** rather than fake certainty.

--- a/docs/MANUAL_TEST_CHECKLIST.md
+++ b/docs/MANUAL_TEST_CHECKLIST.md
@@ -1,0 +1,171 @@
+# Manual Test & Regression Checklist
+
+This checklist is meant to keep **TajsGraphBM** changes grounded in real in-game validation.
+It is intentionally lightweight and tuned for a UE4SS Lua mod rather than a large application repo.
+
+## Before testing
+
+Confirm the following first:
+
+- BetterMart launches normally without the mod
+- UE4SS is installed in the expected location
+- BetterMart-specific signatures/config are in place
+- `enabled.txt` exists for the mod
+- You know which TajsGraphBM commit or branch you are testing
+- You are not mixing in unrelated local tweaks unless the test explicitly requires them
+
+---
+
+## Minimum sanity pass
+
+Run this small pass for most code changes:
+
+1. Launch BetterMart
+2. Load into a save
+3. Open the in-game console
+4. Run `tajsgraph.status`
+5. Run `tajsgraph.apply`
+6. Run `tajsgraph.status` again
+7. Confirm the scene changes in an expected way or, if not, note that explicitly
+8. Watch for console errors, unexpected spam, or missing command handling
+
+Record:
+
+- whether commands are recognized
+- whether anything visibly changes
+- whether errors appear in logs/console
+- whether status counters move in a way that makes sense
+
+---
+
+## Suggested regression areas
+
+### 1) Command flow
+
+Check:
+
+- `tajsgraph.apply`
+- `tajsgraph.status`
+- `tajsgraph.rebaseline`
+- any newly added commands for the feature being tested
+
+Look for:
+
+- command not recognized
+- command recognized but no-op with confusing output
+- duplicated command registration after reload/hot reload
+- unexpected state carried across reloads
+
+### 2) Spotlight/runtime patching
+
+Check:
+
+- a scene with several interior lights
+- a scene with obvious authored spotlight behavior
+- whether patched lights stay visually stable after re-running apply
+
+Look for:
+
+- overbright or dead lights
+- weird cone angles
+- broken visibility/enabled state
+- mobility-related artifacts or failures
+- destroyed/stale cached objects causing errors
+
+### 3) Render/Lumen/MegaLights compatibility
+
+Check:
+
+- whether renderer/postprocess/world writes appear to have effect
+- whether fallback logic still works when some properties are unsupported
+
+Look for:
+
+- no-op writes with misleading success output
+- sudden lighting/shadow regressions after apply
+- settings that only take effect after extra refresh steps
+
+### 4) Post-apply VSM refresh behavior
+
+This mod currently has special handling around VSM refresh behavior.
+
+Check:
+
+- whether a manual `tajsgraph.apply` appears to need an extra refresh/reload behavior to look correct
+- whether shadows update immediately or only after fallback logic
+
+Look for:
+
+- stale shadows
+- scene only correcting itself after a second pass
+- shadow map flicker or obvious instability
+
+### 5) Startup / scheduled / spawn-related behavior
+
+If the change touches scheduling, startup, or spawned-object patch paths, also check:
+
+- fresh launch behavior
+- re-entering/loading into a save
+- object spawn/recovery path if applicable
+- whether background logic over-applies or spams
+
+Look for:
+
+- repeated apply storms
+- missed spawned lights
+- background logic undoing manual state
+- state not surviving expected transitions
+
+---
+
+## Performance sanity check
+
+Not every change needs benchmarking, but changes that touch scanning, scheduling, render compatibility writes, or new light classes should at least get a basic perf sanity pass.
+
+Check:
+
+- whether first apply feels noticeably heavier
+- whether repeated apply causes stutter
+- whether logs become excessively spammy
+- whether scene performance becomes obviously worse after patching
+
+If something feels slower, note:
+
+- map/scene
+- approximate object/light density
+- whether slowdown is one-time or repeated
+- whether the issue disappears after restart
+
+---
+
+## What to attach to PRs / issues
+
+When possible, include:
+
+- TajsGraphBM commit/branch tested
+- BetterMart version/build
+- UE4SS version/tag
+- signature/config source
+- exact console commands used
+- before/after screenshots for visual changes
+- relevant console or log snippets
+- whether this was tested on a clean launch
+
+---
+
+## PR author checklist
+
+Before opening or merging a PR, try to confirm:
+
+- the Lua smoke check passes in CI
+- commands still register and run as expected
+- no obvious regressions in the minimum sanity pass
+- docs/comments were updated if the behavior or workflow changed
+- the PR explains any limitations or untested paths honestly
+
+---
+
+## Maintainer note
+
+This checklist should evolve with the mod.
+If a new runtime subsystem or new command family is added, update this document so contributors test the right things instead of guessing.


### PR DESCRIPTION
## Summary
Adds a lightweight repo-hygiene pass for TajsGraphBM inspired by the structure used in TajsOS, but trimmed down for a small UE4SS/Lua mod repo.

This PR adds:
- GitHub issue templates for bug reports, feature requests, and support questions
- issue template config with links to repo docs
- a lightweight Lua smoke-check workflow for `Scripts/*.lua`
- `docs/KNOWN_GOOD_VERSIONS.md`
- `docs/MANUAL_TEST_CHECKLIST.md`
- a slim pull request template

## Related Issue(s)
Fixes #16

## Why this shape
TajsOS has a more elaborate repo/process setup, but TajsGraphBM is much smaller and more experimental. This PR keeps the same general vibe while focusing on the fields that matter most here: BetterMart version/build, UE4SS version, signature/config source, commands used, scene/save context, and visual/runtime regression risk.

## Notes
- The Lua workflow is intentionally a smoke check, not a full runtime test. It validates syntax with `luac -p` and does basic module/marker loading plus one config alias normalization check.
- The compatibility/version doc uses honest placeholders where exact versions are not yet pinned.
- The manual checklist focuses on command flow, spotlight/runtime patching, render compatibility, VSM refresh behavior, and scheduling-related regression areas.

## Risk
Low. This is repo/process tooling only and does not change runtime mod behavior.
